### PR TITLE
Add dashboard modules for finance management

### DIFF
--- a/resources/js/Components/DashboardCard.jsx
+++ b/resources/js/Components/DashboardCard.jsx
@@ -1,0 +1,15 @@
+import { Link } from '@inertiajs/react';
+
+export default function DashboardCard({ title, href, children }) {
+    return (
+        <Link
+            href={href}
+            className="block rounded-lg border bg-white p-6 shadow-sm transition hover:shadow-md"
+        >
+            <h3 className="mb-2 text-lg font-semibold">{title}</h3>
+            {children && (
+                <p className="text-sm text-gray-600">{children}</p>
+            )}
+        </Link>
+    );
+}

--- a/resources/js/Pages/Bnpl.jsx
+++ b/resources/js/Pages/Bnpl.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Bnpl() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    BNPL
+                </h2>
+            }
+        >
+            <Head title="BNPL" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Track your buy-now-pay-later plans here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/CreditCards.jsx
+++ b/resources/js/Pages/CreditCards.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function CreditCards() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Credit Cards
+                </h2>
+            }
+        >
+            <Head title="Credit Cards" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Manage your credit card accounts and payments here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,4 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import DashboardCard from '@/Components/DashboardCard';
 import { Head } from '@inertiajs/react';
 
 export default function Dashboard() {
@@ -13,11 +14,29 @@ export default function Dashboard() {
             <Head title="Dashboard" />
 
             <div className="py-12">
-                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">
-                            You're logged in!
-                        </div>
+                <div className="mx-auto max-w-7xl space-y-6 sm:px-6 lg:px-8">
+                    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        <DashboardCard title="Expense Tracker" href={route('expenses')}>
+                            Track daily spending and categorize expenses.
+                        </DashboardCard>
+                        <DashboardCard title="BNPL" href={route('bnpl')}>
+                            Monitor buy-now-pay-later balances.
+                        </DashboardCard>
+                        <DashboardCard title="Credit Cards" href={route('credit-cards')}>
+                            Manage credit card accounts and payments.
+                        </DashboardCard>
+                        <DashboardCard title="House Loan" href={route('house-loan')}>
+                            Keep tabs on your mortgage status.
+                        </DashboardCard>
+                        <DashboardCard title="Goals" href={route('goals')}>
+                            Set and monitor savings goals.
+                        </DashboardCard>
+                        <DashboardCard title="Jars" href={route('jars')}>
+                            Allocate budgets into separate jars.
+                        </DashboardCard>
+                        <DashboardCard title="Wishlist" href={route('wishlist')}>
+                            Save items you're planning to buy.
+                        </DashboardCard>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Expenses.jsx
+++ b/resources/js/Pages/Expenses.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Expenses() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Expense Tracker
+                </h2>
+            }
+        >
+            <Head title="Expense Tracker" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Manage your expenses here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Goals.jsx
+++ b/resources/js/Pages/Goals.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Goals() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Goals
+                </h2>
+            }
+        >
+            <Head title="Goals" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Define and monitor your savings goals here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/HouseLoan.jsx
+++ b/resources/js/Pages/HouseLoan.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function HouseLoan() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    House Loan
+                </h2>
+            }
+        >
+            <Head title="House Loan" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Keep track of your mortgage details here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Jars.jsx
+++ b/resources/js/Pages/Jars.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Jars() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Jars
+                </h2>
+            }
+        >
+            <Head title="Jars" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Allocate budgets into separate jars here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/Wishlist.jsx
+++ b/resources/js/Pages/Wishlist.jsx
@@ -1,0 +1,26 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Wishlist() {
+    return (
+        <AuthenticatedLayout
+            header={
+                <h2 className="text-xl font-semibold leading-tight text-gray-800">
+                    Wishlist
+                </h2>
+            }
+        >
+            <Head title="Wishlist" />
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                        <div className="p-6 text-gray-900">
+                            Save items you're planning to purchase here.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,16 @@ Route::get('/dashboard', function () {
 
 Route::get('/', fn() => redirect()->route('dashboard'));
 
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::inertia('/expenses', 'Expenses')->name('expenses');
+    Route::inertia('/bnpl', 'Bnpl')->name('bnpl');
+    Route::inertia('/credit-cards', 'CreditCards')->name('credit-cards');
+    Route::inertia('/house-loan', 'HouseLoan')->name('house-loan');
+    Route::inertia('/goals', 'Goals')->name('goals');
+    Route::inertia('/jars', 'Jars')->name('jars');
+    Route::inertia('/wishlist', 'Wishlist')->name('wishlist');
+});
+
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- add shadcn-style dashboard cards for key finance features
- create placeholder pages for expenses, bnpl, credit cards, house loan, goals, jars and wishlist
- wire up routes for new pages

## Testing
- `npm test` (fails: Missing script: "test")
- `composer install` (fails: curl error 56 / GitHub token required)


------
https://chatgpt.com/codex/tasks/task_e_68ac92556c68832aae7fe44ec6e11908